### PR TITLE
Minor corrections to the UHFQA driver

### DIFF
--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
@@ -2116,7 +2116,7 @@ section: QA Monitor
 group: QA Monitor
 def_value: 1.0
 show_in_measurement_dlg: False
-tooltip: <html><head/><body><p>log2 of the number of averages to perform, i.e. 0 means no averaging, 1 means 2 values are averaged, etc. Maximum setting is 15 meaning 2^15 values are averaged.<br/><b>qas/0/monitor/averages</b></p></body></html>
+tooltip: Number of averages (should be power of 2, e.g., 2, 4, 8, etc.).
 set_cmd: /qas/0/monitor/averages
 get_cmd: /qas/0/monitor/averages
 
@@ -2138,8 +2138,6 @@ section: QA Monitor
 group: QA Monitor
 unit: V
 show_in_measurement_dlg: False
-set_cmd: /qas/0/monitor/inputs/0/wave
-get_cmd: /qas/0/monitor/inputs/0/wave
 permission: READ
 x_name: Time
 x_unit: s
@@ -2150,8 +2148,6 @@ section: QA Monitor
 group: QA Monitor
 unit: V
 show_in_measurement_dlg: False
-set_cmd: /qas/0/monitor/inputs/1/wave
-get_cmd: /qas/0/monitor/inputs/1/wave
 permission: READ
 x_name: Time
 x_unit: s
@@ -2211,7 +2207,7 @@ section: QA Results
 group: QA Results
 def_value: 1
 show_in_measurement_dlg: True
-tooltip: <html><head/><body><p>log2 of the number of averages to perform, i.e. 0 means no averaging, 1 means 2 values are averaged, etc. Maximum setting is 15 meaning 2^15 values are averaged.<br/><b>qas/0/result/averages</b></p></body></html>
+tooltip: Number of averages (should be power of 2, e.g., 2, 4, 8, etc.).
 set_cmd: /qas/0/result/averages
 get_cmd: /qas/0/result/averages
 
@@ -3370,6 +3366,26 @@ def_value: 100e-6
 unit: s
 show_in_measurement_dlg: True
 tooltip: MISSING
+
+[Sequencer - Dead Time]
+label: Dead Time
+datatype: DOUBLE
+section: Sequencer
+group: Sequencer
+def_value: 5e-6
+unit: s
+show_in_measurement_dlg: True
+tooltip: The time in seconds between the time origin t=0 and the end of the period. This parameter determines the time origin t=0.
+
+[Sequencer - Latency]
+label: Latency
+datatype: DOUBLE
+section: Sequencer
+group: Sequencer
+def_value: 160e-9
+unit: s
+show_in_measurement_dlg: True
+tooltip: The latency time in seconds (compensates for different trigger latencies of different instruments).
 
 [Waveform 1]
 datatype: VECTOR

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
@@ -2116,7 +2116,7 @@ section: QA Monitor
 group: QA Monitor
 def_value: 1.0
 show_in_measurement_dlg: False
-tooltip: Number of averages (should be power of 2, e.g., 2, 4, 8, etc.).
+tooltip: <html><head/><body><p>log2 of the number of averages to perform, i.e. 0 means no averaging, 1 means 2 values are averaged, etc. Maximum setting is 15 meaning 2^15 values are averaged.<br/><b>qas/0/monitor/averages</b></p></body></html>
 set_cmd: /qas/0/monitor/averages
 get_cmd: /qas/0/monitor/averages
 
@@ -2138,6 +2138,8 @@ section: QA Monitor
 group: QA Monitor
 unit: V
 show_in_measurement_dlg: False
+set_cmd: /qas/0/monitor/inputs/0/wave
+get_cmd: /qas/0/monitor/inputs/0/wave
 permission: READ
 x_name: Time
 x_unit: s
@@ -2148,6 +2150,8 @@ section: QA Monitor
 group: QA Monitor
 unit: V
 show_in_measurement_dlg: False
+set_cmd: /qas/0/monitor/inputs/1/wave
+get_cmd: /qas/0/monitor/inputs/1/wave
 permission: READ
 x_name: Time
 x_unit: s
@@ -2207,7 +2211,7 @@ section: QA Results
 group: QA Results
 def_value: 1
 show_in_measurement_dlg: True
-tooltip: Number of averages (should be power of 2, e.g., 2, 4, 8, etc.).
+tooltip: <html><head/><body><p>log2 of the number of averages to perform, i.e. 0 means no averaging, 1 means 2 values are averaged, etc. Maximum setting is 15 meaning 2^15 values are averaged.<br/><b>qas/0/result/averages</b></p></body></html>
 set_cmd: /qas/0/result/averages
 get_cmd: /qas/0/result/averages
 
@@ -3366,26 +3370,6 @@ def_value: 100e-6
 unit: s
 show_in_measurement_dlg: True
 tooltip: MISSING
-
-[Sequencer - Dead Time]
-label: Dead Time
-datatype: DOUBLE
-section: Sequencer
-group: Sequencer
-def_value: 5e-6
-unit: s
-show_in_measurement_dlg: True
-tooltip: The time in seconds between the time origin t=0 and the end of the period. This parameter determines the time origin t=0.
-
-[Sequencer - Latency]
-label: Latency
-datatype: DOUBLE
-section: Sequencer
-group: Sequencer
-def_value: 160e-9
-unit: s
-show_in_measurement_dlg: True
-tooltip: The latency time in seconds (compensates for different trigger latencies of different instruments).
 
 [Waveform 1]
 datatype: VECTOR

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
@@ -113,7 +113,7 @@ group: Input 1
 def_value: 1.0
 unit: V
 show_in_measurement_dlg: False
-tooltip: <html><head/><body><p>Defines the gain of the analog input amplifier. The range should exceed the incoming signal by roughly a factor two including a potential DC offset. The instrument selects the next higher available range relative to a value inserted by the user. A suitable choice of this setting optimizes the accuracy and signal-to-noise ratio by ensuring that the full dynamic range of the input ADC is used.<br/><b>sigins/0/range</b></p></body></html>
+tooltip: Defines the gain of the analog input amplifier. The range should exceed the incoming signal by roughly a factor two including a potential DC offset. The instrument selects the next higher available range relative to a value inserted by the user. A suitable choice of this setting optimizes the accuracy and signal-to-noise ratio by ensuring that the full dynamic range of the input ADC is used.
 set_cmd: /sigins/0/range
 get_cmd: /sigins/0/range
 
@@ -2587,7 +2587,7 @@ group: Results
 unit: V
 show_in_measurement_dlg: True
 permission: READ
-
+tooltip: Demodulation result (complex value)
 
 #########################################
 # SECTION: Channel 1
@@ -3279,7 +3279,7 @@ section: Sequencer
 group: Control
 def_value: false
 show_in_measurement_dlg: True
-tooltip: <html><head/><body><p>Activates the AWG.<br/><b>awgs/0/enable</b></p></body></html>
+tooltip: Activates the AWG.
 set_cmd: /awgs/0/enable
 get_cmd: /awgs/0/enable
 
@@ -3332,6 +3332,7 @@ cmd_def_2: 1
 combo_def_2: Send Trigger
 cmd_def_3: 2
 combo_def_3: External Trigger
+tooltip: This parameter specifies whether the UHFQA is used as a master trigger, expects a trigger or is used by itself.
 
 [Sequencer - Alignment]
 label: Alignment
@@ -3476,7 +3477,7 @@ group: Sequence Parameters
 def_value: 10000000.0
 unit: Hz
 show_in_measurement_dlg: False
-tooltip: <html><head/><body><p>Frequency control for each oscillator.<br/><b>oscs/0/freq</b></p></body></html>
+tooltip: Modulation frequency
 set_cmd: oscs/0/freq
 get_cmd: oscs/0/freq
 state_quant: Sequencer - Sequence

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.py
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.py
@@ -134,8 +134,7 @@ class Driver(LabberDriver):
         return value
 
     def performGetValue(self, quant, options={}):
-        """Perform the Set Value instrument operation. This function should
-        return the actual value set by the instrument"""
+        """Perform the Get Value instrument operation"""
         if quant.get_cmd:
             # if a 'get_cmd' is defined, use it to return the node value
             return self.controller._get(quant.get_cmd)
@@ -156,6 +155,12 @@ class Driver(LabberDriver):
         elif quant.name == "Result Demod 1-2":
             # calculate 'demod 1-2' value
             return self.get_demod_12()
+        elif quant.name == 'QA Monitor - Input 1':
+            value = quant.getTraceDict(self.controller._get('/qas/0/monitor/inputs/0/wave'), dt=1/1.8e9)
+            return value
+        elif quant.name == 'QA Monitor - Input 2':
+            value = quant.getTraceDict(self.controller._get('/qas/0/monitor/inputs/1/wave'), dt=1/1.8e9)
+            return value
         else:
             return quant.getValue()
 
@@ -207,6 +212,8 @@ class Driver(LabberDriver):
             trigger_delay=self.getValue(base_name + "Trigger Delay"),
             readout_length=self.getValue(base_name + "Readout Length"),
             clock_rate=1.8e9,
+            latency=self.getValue(base_name + "Latency"),
+            dead_time=self.getValue(base_name + "Dead Time"),
         )
         if params["sequence_type"] == "Custom":
             params.update(path=self.getValue("Custom Sequence - Path"))

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.py
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.py
@@ -134,7 +134,8 @@ class Driver(LabberDriver):
         return value
 
     def performGetValue(self, quant, options={}):
-        """Perform the Get Value instrument operation"""
+        """Perform the Set Value instrument operation. This function should
+        return the actual value set by the instrument"""
         if quant.get_cmd:
             # if a 'get_cmd' is defined, use it to return the node value
             return self.controller._get(quant.get_cmd)
@@ -155,12 +156,6 @@ class Driver(LabberDriver):
         elif quant.name == "Result Demod 1-2":
             # calculate 'demod 1-2' value
             return self.get_demod_12()
-        elif quant.name == 'QA Monitor - Input 1':
-            value = quant.getTraceDict(self.controller._get('/qas/0/monitor/inputs/0/wave'), dt=1/1.8e9)
-            return value
-        elif quant.name == 'QA Monitor - Input 2':
-            value = quant.getTraceDict(self.controller._get('/qas/0/monitor/inputs/1/wave'), dt=1/1.8e9)
-            return value
         else:
             return quant.getValue()
 
@@ -212,8 +207,6 @@ class Driver(LabberDriver):
             trigger_delay=self.getValue(base_name + "Trigger Delay"),
             readout_length=self.getValue(base_name + "Readout Length"),
             clock_rate=1.8e9,
-            latency=self.getValue(base_name + "Latency"),
-            dead_time=self.getValue(base_name + "Dead Time"),
         )
         if params["sequence_type"] == "Custom":
             params.update(path=self.getValue("Custom Sequence - Path"))


### PR DESCRIPTION
1) Added support for dead_time and latency parameters
2) Fixed tooltips for 'QA Monitor - Averages' and 'QA Results - HW Averages'
3) Added the code to provide proper time arrays for 'QA Monitor - Input 1' and 'QA Monitor - Input 2' data.