### PR TITLE
Minor corrections to the UHFQA driver

### DIFF
--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
@@ -3371,6 +3371,26 @@ unit: s
 show_in_measurement_dlg: True
 tooltip: MISSING
 
+[Sequencer - Dead Time]
+label: Dead Time
+datatype: DOUBLE
+section: Sequencer
+group: Sequencer
+def_value: 5e-6
+unit: s
+show_in_measurement_dlg: True
+tooltip: The time in seconds between the time origin t=0 and the end of the period. This parameter determines the time origin t=0.
+
+[Sequencer - Latency]
+label: Latency
+datatype: DOUBLE
+section: Sequencer
+group: Sequencer
+def_value: 160e-9
+unit: s
+show_in_measurement_dlg: True
+tooltip: The latency time in seconds (compensates for different trigger latencies of different instruments).
+
 [Waveform 1]
 datatype: VECTOR
 section: Sequencer

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
@@ -2116,7 +2116,7 @@ section: QA Monitor
 group: QA Monitor
 def_value: 1.0
 show_in_measurement_dlg: False
-tooltip: <html><head/><body><p>log2 of the number of averages to perform, i.e. 0 means no averaging, 1 means 2 values are averaged, etc. Maximum setting is 15 meaning 2^15 values are averaged.<br/><b>qas/0/monitor/averages</b></p></body></html>
+tooltip: Number of averages (should be power of 2, e.g., 2, 4, 8, etc.).
 set_cmd: /qas/0/monitor/averages
 get_cmd: /qas/0/monitor/averages
 
@@ -2211,7 +2211,7 @@ section: QA Results
 group: QA Results
 def_value: 1
 show_in_measurement_dlg: True
-tooltip: <html><head/><body><p>log2 of the number of averages to perform, i.e. 0 means no averaging, 1 means 2 values are averaged, etc. Maximum setting is 15 meaning 2^15 values are averaged.<br/><b>qas/0/result/averages</b></p></body></html>
+tooltip: Number of averages (should be power of 2, e.g., 2, 4, 8, etc.).
 set_cmd: /qas/0/result/averages
 get_cmd: /qas/0/result/averages
 

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
@@ -113,7 +113,7 @@ group: Input 1
 def_value: 1.0
 unit: V
 show_in_measurement_dlg: False
-tooltip: <html><head/><body><p>Defines the gain of the analog input amplifier. The range should exceed the incoming signal by roughly a factor two including a potential DC offset. The instrument selects the next higher available range relative to a value inserted by the user. A suitable choice of this setting optimizes the accuracy and signal-to-noise ratio by ensuring that the full dynamic range of the input ADC is used.<br/><b>sigins/0/range</b></p></body></html>
+tooltip: Defines the gain of the analog input amplifier. The range should exceed the incoming signal by roughly a factor two including a potential DC offset. The instrument selects the next higher available range relative to a value inserted by the user. A suitable choice of this setting optimizes the accuracy and signal-to-noise ratio by ensuring that the full dynamic range of the input ADC is used.
 set_cmd: /sigins/0/range
 get_cmd: /sigins/0/range
 
@@ -124,7 +124,7 @@ section: Inputs/Outputs
 group: Input 1
 def_value: 1.0
 show_in_measurement_dlg: False
-tooltip: <html><head/><body><p>Applies the given scaling factor to the input signal.<br/><b>sigins/0/scaling</b></p></body></html>
+tooltip: Applies the given scaling factor to the input signal.
 set_cmd: /sigins/0/scaling
 get_cmd: /sigins/0/scaling
 
@@ -135,7 +135,7 @@ section: Inputs/Outputs
 group: Input 1
 def_value: 0
 show_in_measurement_dlg: False
-tooltip: <html><head/><body><p>Defines the input coupling for the Signal Inputs. AC coupling inserts a high-pass filter.<br/><b>sigins/0/ac</b></p></body></html>
+tooltip: Defines the input coupling for the Signal Inputs. AC coupling inserts a high-pass filter.
 set_cmd: /sigins/0/ac
 get_cmd: /sigins/0/ac
 
@@ -146,7 +146,7 @@ section: Inputs/Outputs
 group: Input 1
 def_value: 1
 show_in_measurement_dlg: False
-tooltip: <html><head/><body><p>Switches between 50 Ohm (ON) and 1 M Ohm (OFF).<br/><b>sigins/0/imp50</b></p></body></html>
+tooltip: Switches between 50 Ohm (ON) and 1 M Ohm (OFF).>
 set_cmd: /sigins/0/imp50
 get_cmd: /sigins/0/imp50
 
@@ -156,7 +156,7 @@ datatype: COMBO
 section: Inputs/Outputs
 group: Input 1
 show_in_measurement_dlg: False
-tooltip: <html><head/><body><p>Switch input mode between normal (OFF), inverted, and differential. The differential modes are implemented digitally and are not suited for analog common-mode rejection.<br/><b>sigins/0/diff</b></p></body></html>
+tooltip: Switch input mode between normal (OFF), inverted, and differential. The differential modes are implemented digitally and are not suited for analog common-mode rejection.
 set_cmd: /sigins/0/diff
 get_cmd: /sigins/0/diff
 cmd_def_1: 0

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
@@ -2138,8 +2138,6 @@ section: QA Monitor
 group: QA Monitor
 unit: V
 show_in_measurement_dlg: False
-set_cmd: /qas/0/monitor/inputs/0/wave
-get_cmd: /qas/0/monitor/inputs/0/wave
 permission: READ
 x_name: Time
 x_unit: s
@@ -2150,8 +2148,6 @@ section: QA Monitor
 group: QA Monitor
 unit: V
 show_in_measurement_dlg: False
-set_cmd: /qas/0/monitor/inputs/1/wave
-get_cmd: /qas/0/monitor/inputs/1/wave
 permission: READ
 x_name: Time
 x_unit: s

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
@@ -2587,7 +2587,7 @@ group: Results
 unit: V
 show_in_measurement_dlg: True
 permission: READ
-
+tooltip: Demodulation result (complex value)
 
 #########################################
 # SECTION: Channel 1
@@ -3332,6 +3332,7 @@ cmd_def_2: 1
 combo_def_2: Send Trigger
 cmd_def_3: 2
 combo_def_3: External Trigger
+tooltip: This parameter specifies whether the UHFQA is used as a master trigger, expects a trigger or is used by itself.
 
 [Sequencer - Alignment]
 label: Alignment

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.py
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.py
@@ -134,8 +134,7 @@ class Driver(LabberDriver):
         return value
 
     def performGetValue(self, quant, options={}):
-        """Perform the Set Value instrument operation. This function should
-        return the actual value set by the instrument"""
+        """Perform the Get Value instrument operation"""
         if quant.get_cmd:
             # if a 'get_cmd' is defined, use it to return the node value
             return self.controller._get(quant.get_cmd)
@@ -156,6 +155,12 @@ class Driver(LabberDriver):
         elif quant.name == "Result Demod 1-2":
             # calculate 'demod 1-2' value
             return self.get_demod_12()
+        elif quant.name == 'QA Monitor - Input 1':
+            value = quant.getTraceDict(self.controller._get('/qas/0/monitor/inputs/0/wave'), dt=1/1.8e9)
+            return value
+        elif quant.name == 'QA Monitor - Input 2':
+            value = quant.getTraceDict(self.controller._get('/qas/0/monitor/inputs/1/wave'), dt=1/1.8e9)
+            return value
         else:
             return quant.getValue()
 

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.py
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.py
@@ -207,6 +207,8 @@ class Driver(LabberDriver):
             trigger_delay=self.getValue(base_name + "Trigger Delay"),
             readout_length=self.getValue(base_name + "Readout Length"),
             clock_rate=1.8e9,
+            latency=self.getValue(base_name + "Latency"),
+            dead_time=self.getValue(base_name + "Dead Time"),
         )
         if params["sequence_type"] == "Custom":
             params.update(path=self.getValue("Custom Sequence - Path"))


### PR DESCRIPTION
1.  Added support for 'dead_time' and 'latency' parameters
Please see details about 'dead_time' and 'latency' parameters in the documentation for sequence parameters [here](https://docs.zhinst.com/zhinst-toolkit/en/latest/examples/notebooks/example3-1_SequenceParameters.html) and [here](https://docs.zhinst.com/zhinst-toolkit/en/latest/zhinst-toolkit/awg.html). 
If a user wants to control the position of the time origin t=0 relative to the trigger signal, the support for the dead_time parameter is needed. In particular, if a user wants the time origin to start immediately after the trigger signal, they need to set dead_time value to the difference between the period and latency times, dead_time = period - latency. 
As a general remark, zhinst-labber drivers should give access to all available parameters provided by zhinst-toolkit for a given instrument. The current version of zhinst-labber is very limited in that sense. 
2.  Fixed tooltips for 'QA Monitor - Averages' and 'QA Results - HW Averages'
Tooltips for 'QA Monitor - Averages' and 'QA Results - HW Averages' are outdated. Apparently, the definitions of those parameter have been changed. Currently, those parameters correspond to a number of averages (not to log2() of the number of averages).
3. Added the code to provide proper time arrays for 'QA Monitor - Input 1' and 'QA Monitor - Input 2' data.
In Labber, it is assumed that instruments such as a signal generator, a digitizer, etc., return data array with additional time array. Please see the description of getTraceDict() [here](http://labber.org/online-doc/html/Drivers.html). In that case, a user can do signal processing using Labber interface (e.g., FFT).