### PR TITLE
HDAWG driver update

### DIFF
--- a/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.ini
+++ b/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.ini
@@ -1730,6 +1730,22 @@ cmd_def_2: 1
 combo_def_2: End with Trigger
 
 
+[Sequencer 1-2 - Rerun]
+label: Rerun
+datatype: COMBO
+section: Sequencer 1-2
+group: Sequencer 1-2
+def_value: Off
+show_in_measurement_dlg: False
+tooltip: Reruns the Sequencer program continuously. This way of looping a program results in timing jitter. For a jitter free signal implement a loop directly in the sequence program.
+set_cmd: /awgs/0/single
+get_cmd: /awgs/0/single
+cmd_def_1: 0
+combo_def_1: On
+cmd_def_2: 1
+combo_def_2: Off
+
+
 [Sequencer 1-2 - Sequence]
 label: Sequence
 datatype: COMBO
@@ -2374,6 +2390,21 @@ cmd_def_1: 0
 combo_def_1: Start with Trigger
 cmd_def_2: 1
 combo_def_2: End with Trigger
+
+[Sequencer 3-4 - Rerun]
+label: Rerun
+datatype: COMBO
+section: Sequencer 3-4
+group: Sequencer 3-4
+def_value: Off
+show_in_measurement_dlg: False
+tooltip: Reruns the Sequencer program continuously. This way of looping a program results in timing jitter. For a jitter free signal implement a loop directly in the sequence program.
+set_cmd: /awgs/1/single
+get_cmd: /awgs/1/single
+cmd_def_1: 0
+combo_def_1: On
+cmd_def_2: 1
+combo_def_2: Off
 
 [Sequencer 3-4 - Sequence]
 label: Sequence
@@ -3020,6 +3051,21 @@ cmd_def_1: 0
 combo_def_1: Start with Trigger
 cmd_def_2: 1
 combo_def_2: End with Trigger
+
+[Sequencer 5-6 - Rerun]
+label: Rerun
+datatype: COMBO
+section: Sequencer 5-6
+group: Sequencer 5-6
+def_value: Off
+show_in_measurement_dlg: False
+tooltip: Reruns the Sequencer program continuously. This way of looping a program results in timing jitter. For a jitter free signal implement a loop directly in the sequence program.
+set_cmd: /awgs/2/single
+get_cmd: /awgs/2/single
+cmd_def_1: 0
+combo_def_1: On
+cmd_def_2: 1
+combo_def_2: Off
 
 #########################################
 # SECTION: Sequencer 5-6
@@ -3674,6 +3720,21 @@ cmd_def_1: 0
 combo_def_1: Start with Trigger
 cmd_def_2: 1
 combo_def_2: End with Trigger
+
+[Sequencer 7-8 - Rerun]
+label: Rerun
+datatype: COMBO
+section: Sequencer 7-8
+group: Sequencer 7-8
+def_value: Off
+show_in_measurement_dlg: False
+tooltip: Reruns the Sequencer program continuously. This way of looping a program results in timing jitter. For a jitter free signal implement a loop directly in the sequence program.
+set_cmd: /awgs/3/single
+get_cmd: /awgs/3/single
+cmd_def_1: 0
+combo_def_1: On
+cmd_def_2: 1
+combo_def_2: Off
 
 [Sequencer 7-8 - Trigger Delay]
 label: Trigger Delay

--- a/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.py
+++ b/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.py
@@ -137,7 +137,14 @@ class Driver(LabberDriver):
                 # sequencer needs to be recompiled
                 if loop_index + 1 == n_HW_loop:
                     self.compile_sequencers()
-
+            # if any of AWGs is in the 'Send Trigger' mode, start this AWG and wait until it stops
+            for i in range(4):
+                base_name = f"Sequencer {2*i + 1}-{2*i + 2} - "
+                trigger = self.getValue(base_name + "Trigger Mode")
+                sequence = self.getValue(base_name + "Sequence")
+                if trigger == "Send Trigger" and sequence != "None":
+                    self.controller.awgs[i].run()
+                    self.controller.awgs[i].wait_done()
         return value
 
     def performGetValue(self, quant, options={}):

--- a/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.py
+++ b/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.py
@@ -73,7 +73,11 @@ class Driver(LabberDriver):
             if value:
                 self.controller.awgs[i].enable_iq_modulation()
             else:
-                self.controller.awgs[i].disable_iq_modulation()
+                self.controller.awgs[i].disable_iq_modulation()    # overrides '.../system/awg/oscillatorcontrol' value for all channels
+                # fix '.../system/awg/oscillatorcontrol' value by calling enable_iq_modulation()
+                for value1 in range(4):
+                    if self.controller.awgs[value1]._iq_modulation:
+                        self.controller.awgs[value1].enable_iq_modulation()
 
         # sequencer modulation frequency
         if quant.name.endswith("Modulation Frequency"):

--- a/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.py
+++ b/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.py
@@ -247,8 +247,7 @@ class Driver(LabberDriver):
                 ):
                     self.controller.awgs[seq].compile()
                 if sequence_type == "Simple":
-                    self.controller.awgs[seq].compile()
-                    self.controller.awgs[seq].upload_waveforms()
+                    self.controller.awgs[seq].compile_and_upload_waveforms()
 
 
 """


### PR DESCRIPTION
1. When disable_iq_modulation() is called for any AWG core, it disables '.../system/awg/oscillatorcontrol' which is global for all other AWG cores. Therefore, it is necessary to repeat enable_iq_modulation() for those AWG cores that use IQ modulation.

2. Add Rerun control for sequencer programs 

3. Use compile_and_upload_waveforms() for the "Simple" sequence

4. Add the code to start AWG in Send Trigger mode.