### PR TITLE
 HDAWG driver updates

### DIFF
--- a/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.ini
+++ b/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.ini
@@ -6,7 +6,7 @@
 name: Zurich Instruments HDAWG
 
 # The version string should be updated whenever changes are made to this config file
-version: 1.0
+version: 1.1
 
 # Name of folder containing the code defining a custom driver. Do not define this item
 # or leave it blank for any standard driver based on the built-in VISA interface.
@@ -65,6 +65,67 @@ use_visa: False
 #   stop_cmd:      Command used to stop a sweep
 
 
+#########################################
+# SECTION: Setup
+# GROUP: Revisions
+
+[Revisions - Data Server]
+label: Data Server
+datatype: STRING
+section: Setup
+group: Revisions
+def_value:
+tooltip: <html><head/><body><p>Contains the revision number of the Zurich Instruments Data Server.<br/><b>/zi/about/revision</b></p></body></html>
+get_cmd: /zi/about/revision
+permission: READ
+
+[Revisions - Firmware]
+label: Firmware
+datatype: STRING
+section: Setup
+group: Revisions
+def_value:
+tooltip: <html><head/><body><p>Revision of the device-internal controller software.<br/><b>/system/fwrevision</b></p></body></html>
+get_cmd: /system/fwrevision
+permission: READ
+
+[Revisions - FPGA]
+label: FPGA
+datatype: STRING
+section: Setup
+group: Revisions
+def_value:
+tooltip: <html><head/><body><p>HDL firmware revision.<br/><b>/system/fpgarevision</b></p></body></html>
+get_cmd: /system/fpgarevision
+permission: READ
+
+
+#########################################
+# SECTION: Setup
+# GROUP: Preset
+
+[Preset - Factory Reset]
+label: Factory Reset
+datatype: BUTTON
+section: Setup
+group: Preset
+tooltip: <html><head/><body><p>Load the factory default settings.<br/></p></body></html>
+permission: BOTH
+
+
+#########################################
+# SECTION: Setup
+# GROUP: PQSC
+
+[PQSC - Connect to PQSC]
+label: Connect to PQSC
+datatype: BOOLEAN
+section: Setup
+group: PQSC
+def_value: False
+tooltip: <html><head/><body><p>Configure the instrument to work with PQSC.<br/></p></body></html>
+permission: WRITE
+show_in_measurement_dlg: True
 
 
 #########################################
@@ -81,6 +142,8 @@ show_in_measurement_dlg: True
 tooltip: <html><head/><body><p>Reference clock source.<br/><b>system/clocks/referenceclock/source</b></p></body></html>
 set_cmd: /system/clocks/referenceclock/source
 get_cmd: /system/clocks/referenceclock/source
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
 cmd_def_1: 0
 combo_def_1: Internal
 cmd_def_2: 1
@@ -1713,8 +1776,9 @@ combo_def_1: None
 cmd_def_2: 1
 combo_def_2: Send Trigger
 cmd_def_3: 2
-combo_def_3: External Trigger
-
+combo_def_3: Receive Trigger
+cmd_def_4: 3
+combo_def_4: ZSync Trigger
 
 [Sequencer 1-2 - Alignment]
 label: Alignment
@@ -1730,20 +1794,20 @@ cmd_def_2: 1
 combo_def_2: End with Trigger
 
 
-[Sequencer 1-2 - Rerun]
-label: Rerun
+[Sequencer 1-2 - Single]
+label: Single
 datatype: COMBO
 section: Sequencer 1-2
 group: Sequencer 1-2
-def_value: Off
+def_value: On
 show_in_measurement_dlg: False
-tooltip: Reruns the Sequencer program continuously. This way of looping a program results in timing jitter. For a jitter free signal implement a loop directly in the sequence program.
+tooltip: Puts the Sequencer into single-shot mod.
 set_cmd: /awgs/0/single
 get_cmd: /awgs/0/single
 cmd_def_1: 0
-combo_def_1: On
+combo_def_1: Off
 cmd_def_2: 1
-combo_def_2: Off
+combo_def_2: On
 
 
 [Sequencer 1-2 - Sequence]
@@ -1786,7 +1850,7 @@ show_in_measurement_dlg: False
 def_value: 0
 unit: s
 state_quant: Sequencer 1-2 - Trigger Mode
-state_value_1: External Trigger
+state_value_1: Receive Trigger
 
 [Sequencer 1-2 - Repetitions]
 label: Repetitions
@@ -2193,6 +2257,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a trigger for the playback of a wave in connecton with waitDIOTrigger().<br/><b>awgs/0/dio/strobe/index</b></p></body></html>
 set_cmd: /awgs/0/dio/strobe/index
 get_cmd: /awgs/0/dio/strobe/index
+state_quant: Sequencer 1-2 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2206,6 +2274,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Select the signal edge that should activate the strobe trigger.<br/><b>awgs/0/dio/strobe/slope</b></p></body></html>
 set_cmd: /awgs/0/dio/strobe/slope
 get_cmd: /awgs/0/dio/strobe/slope
+state_quant: Sequencer 1-2 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -2227,6 +2299,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a valid bit.<br/><b>awgs/0/dio/valid/index</b></p></body></html>
 set_cmd: /awgs/0/dio/valid/index
 get_cmd: /awgs/0/dio/valid/index
+state_quant: Sequencer 1-2 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2240,6 +2316,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Polarity of the VALID bit that indicates that a codeword is available on the bus.<br/><b>awgs/0/dio/valid/polarity</b></p></body></html>
 set_cmd: /awgs/0/dio/valid/polarity
 get_cmd: /awgs/0/dio/valid/polarity
+state_quant: Sequencer 1-2 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -2261,6 +2341,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO bits to be used for waveform selection in connection with playWaveDIO().<br/><b>awgs/0/dio/mask/value</b></p></body></html>
 set_cmd: /awgs/0/dio/mask/value
 get_cmd: /awgs/0/dio/mask/value
+state_quant: Sequencer 1-2 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2274,6 +2358,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Defines the amount of bit shifting to apply for the DIO wave selection.<br/><b>awgs/0/dio/mask/shift</b></p></body></html>
 set_cmd: /awgs/0/dio/mask/shift
 get_cmd: /awgs/0/dio/mask/shift
+state_quant: Sequencer 1-2 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2376,7 +2464,9 @@ combo_def_1: None
 cmd_def_2: 1
 combo_def_2: Send Trigger
 cmd_def_3: 2
-combo_def_3: External Trigger
+combo_def_3: Receive Trigger
+cmd_def_4: 3
+combo_def_4: ZSync Trigger
 
 [Sequencer 3-4 - Alignment]
 label: Alignment
@@ -2391,20 +2481,20 @@ combo_def_1: Start with Trigger
 cmd_def_2: 1
 combo_def_2: End with Trigger
 
-[Sequencer 3-4 - Rerun]
-label: Rerun
+[Sequencer 3-4 - Single]
+label: Single
 datatype: COMBO
 section: Sequencer 3-4
 group: Sequencer 3-4
-def_value: Off
+def_value: On
 show_in_measurement_dlg: False
-tooltip: Reruns the Sequencer program continuously. This way of looping a program results in timing jitter. For a jitter free signal implement a loop directly in the sequence program.
+tooltip: Puts the Sequencer into single-shot mod.
 set_cmd: /awgs/1/single
 get_cmd: /awgs/1/single
 cmd_def_1: 0
-combo_def_1: On
+combo_def_1: Off
 cmd_def_2: 1
-combo_def_2: Off
+combo_def_2: On
 
 [Sequencer 3-4 - Sequence]
 label: Sequence
@@ -2445,7 +2535,7 @@ show_in_measurement_dlg: False
 def_value: 0
 unit: s
 state_quant: Sequencer 3-4 - Trigger Mode
-state_value_1: External Trigger
+state_value_1: Receive Trigger
 
 [Sequencer 3-4 - Repetitions]
 label: Repetitions
@@ -2854,6 +2944,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a trigger for the playback of a wave in connecton with waitDIOTrigger().<br/><b>awgs/1/dio/strobe/index</b></p></body></html>
 set_cmd: /awgs/1/dio/strobe/index
 get_cmd: /awgs/1/dio/strobe/index
+state_quant: Sequencer 3-4 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2867,6 +2961,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Select the signal edge that should activate the strobe trigger.<br/><b>awgs/1/dio/strobe/slope</b></p></body></html>
 set_cmd: /awgs/1/dio/strobe/slope
 get_cmd: /awgs/1/dio/strobe/slope
+state_quant: Sequencer 3-4 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -2888,6 +2986,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a valid bit.<br/><b>awgs/1/dio/valid/index</b></p></body></html>
 set_cmd: /awgs/1/dio/valid/index
 get_cmd: /awgs/1/dio/valid/index
+state_quant: Sequencer 3-4 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2901,6 +3003,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Polarity of the VALID bit that indicates that a codeword is available on the bus.<br/><b>awgs/1/dio/valid/polarity</b></p></body></html>
 set_cmd: /awgs/1/dio/valid/polarity
 get_cmd: /awgs/1/dio/valid/polarity
+state_quant: Sequencer 3-4 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -2922,6 +3028,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO bits to be used for waveform selection in connection with playWaveDIO().<br/><b>awgs/1/dio/mask/value</b></p></body></html>
 set_cmd: /awgs/1/dio/mask/value
 get_cmd: /awgs/1/dio/mask/value
+state_quant: Sequencer 3-4 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2935,6 +3045,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Defines the amount of bit shifting to apply for the DIO wave selection.<br/><b>awgs/1/dio/mask/shift</b></p></body></html>
 set_cmd: /awgs/1/dio/mask/shift
 get_cmd: /awgs/1/dio/mask/shift
+state_quant: Sequencer 3-4 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -3037,7 +3151,9 @@ combo_def_1: None
 cmd_def_2: 1
 combo_def_2: Send Trigger
 cmd_def_3: 2
-combo_def_3: External Trigger
+combo_def_3: Receive Trigger
+cmd_def_4: 3
+combo_def_4: ZSync Trigger
 
 [Sequencer 5-6 - Alignment]
 label: Alignment
@@ -3052,20 +3168,20 @@ combo_def_1: Start with Trigger
 cmd_def_2: 1
 combo_def_2: End with Trigger
 
-[Sequencer 5-6 - Rerun]
-label: Rerun
+[Sequencer 5-6 - Single]
+label: Single
 datatype: COMBO
 section: Sequencer 5-6
 group: Sequencer 5-6
-def_value: Off
+def_value: On
 show_in_measurement_dlg: False
-tooltip: Reruns the Sequencer program continuously. This way of looping a program results in timing jitter. For a jitter free signal implement a loop directly in the sequence program.
+tooltip: Puts the Sequencer into single-shot mod.
 set_cmd: /awgs/2/single
 get_cmd: /awgs/2/single
 cmd_def_1: 0
-combo_def_1: On
+combo_def_1: Off
 cmd_def_2: 1
-combo_def_2: Off
+combo_def_2: On
 
 #########################################
 # SECTION: Sequencer 5-6
@@ -3080,7 +3196,7 @@ show_in_measurement_dlg: False
 def_value: 0
 unit: s
 state_quant: Sequencer 5-6 - Trigger Mode
-state_value_1: External Trigger
+state_value_1: Receive Trigger
 
 [Sequencer 5-6 - Repetitions]
 label: Repetitions
@@ -3522,6 +3638,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a trigger for the playback of a wave in connecton with waitDIOTrigger().<br/><b>awgs/2/dio/strobe/index</b></p></body></html>
 set_cmd: /awgs/2/dio/strobe/index
 get_cmd: /awgs/2/dio/strobe/index
+state_quant: Sequencer 5-6 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -3535,6 +3655,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Select the signal edge that should activate the strobe trigger.<br/><b>awgs/2/dio/strobe/slope</b></p></body></html>
 set_cmd: /awgs/2/dio/strobe/slope
 get_cmd: /awgs/2/dio/strobe/slope
+state_quant: Sequencer 5-6 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -3556,6 +3680,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a valid bit.<br/><b>awgs/2/dio/valid/index</b></p></body></html>
 set_cmd: /awgs/2/dio/valid/index
 get_cmd: /awgs/2/dio/valid/index
+state_quant: Sequencer 5-6 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -3569,6 +3697,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Polarity of the VALID bit that indicates that a codeword is available on the bus.<br/><b>awgs/2/dio/valid/polarity</b></p></body></html>
 set_cmd: /awgs/2/dio/valid/polarity
 get_cmd: /awgs/2/dio/valid/polarity
+state_quant: Sequencer 5-6 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -3590,6 +3722,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO bits to be used for waveform selection in connection with playWaveDIO().<br/><b>awgs/2/dio/mask/value</b></p></body></html>
 set_cmd: /awgs/2/dio/mask/value
 get_cmd: /awgs/2/dio/mask/value
+state_quant: Sequencer 5-6 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -3603,6 +3739,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Defines the amount of bit shifting to apply for the DIO wave selection.<br/><b>awgs/2/dio/mask/shift</b></p></body></html>
 set_cmd: /awgs/2/dio/mask/shift
 get_cmd: /awgs/2/dio/mask/shift
+state_quant: Sequencer 5-6 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -3705,7 +3845,9 @@ combo_def_1: None
 cmd_def_2: 1
 combo_def_2: Send Trigger
 cmd_def_3: 2
-combo_def_3: External Trigger
+combo_def_3: Receive Trigger
+cmd_def_4: 3
+combo_def_4: ZSync Trigger
 
 
 [Sequencer 7-8 - Alignment]
@@ -3721,20 +3863,20 @@ combo_def_1: Start with Trigger
 cmd_def_2: 1
 combo_def_2: End with Trigger
 
-[Sequencer 7-8 - Rerun]
-label: Rerun
+[Sequencer 7-8 - Single]
+label: Single
 datatype: COMBO
 section: Sequencer 7-8
 group: Sequencer 7-8
-def_value: Off
+def_value: On
 show_in_measurement_dlg: False
-tooltip: Reruns the Sequencer program continuously. This way of looping a program results in timing jitter. For a jitter free signal implement a loop directly in the sequence program.
+tooltip: Puts the Sequencer into single-shot mod.
 set_cmd: /awgs/3/single
 get_cmd: /awgs/3/single
 cmd_def_1: 0
-combo_def_1: On
+combo_def_1: Off
 cmd_def_2: 1
-combo_def_2: Off
+combo_def_2: On
 
 [Sequencer 7-8 - Trigger Delay]
 label: Trigger Delay
@@ -3745,7 +3887,7 @@ show_in_measurement_dlg: False
 def_value: 0
 unit: s
 state_quant: Sequencer 7-8 - Trigger Mode
-state_value_1: External Trigger
+state_value_1: Receive Trigger
 
 [Sequencer 7-8 - Repetitions]
 label: Repetitions
@@ -4190,6 +4332,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a trigger for the playback of a wave in connecton with waitDIOTrigger().<br/><b>awgs/3/dio/strobe/index</b></p></body></html>
 set_cmd: /awgs/3/dio/strobe/index
 get_cmd: /awgs/3/dio/strobe/index
+state_quant: Sequencer 7-8 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -4203,6 +4349,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Select the signal edge that should activate the strobe trigger.<br/><b>awgs/3/dio/strobe/slope</b></p></body></html>
 set_cmd: /awgs/3/dio/strobe/slope
 get_cmd: /awgs/3/dio/strobe/slope
+state_quant: Sequencer 7-8 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -4224,6 +4374,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a valid bit.<br/><b>awgs/3/dio/valid/index</b></p></body></html>
 set_cmd: /awgs/3/dio/valid/index
 get_cmd: /awgs/3/dio/valid/index
+state_quant: Sequencer 7-8 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -4237,6 +4391,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Polarity of the VALID bit that indicates that a codeword is available on the bus.<br/><b>awgs/3/dio/valid/polarity</b></p></body></html>
 set_cmd: /awgs/3/dio/valid/polarity
 get_cmd: /awgs/3/dio/valid/polarity
+state_quant: Sequencer 7-8 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -4258,6 +4416,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO bits to be used for waveform selection in connection with playWaveDIO().<br/><b>awgs/3/dio/mask/value</b></p></body></html>
 set_cmd: /awgs/3/dio/mask/value
 get_cmd: /awgs/3/dio/mask/value
+state_quant: Sequencer 7-8 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -4271,6 +4433,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Defines the amount of bit shifting to apply for the DIO wave selection.<br/><b>awgs/3/dio/mask/shift</b></p></body></html>
 set_cmd: /awgs/3/dio/mask/shift
 get_cmd: /awgs/3/dio/mask/shift
+state_quant: Sequencer 7-8 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -5510,6 +5676,46 @@ model_value_1: HDAWG8 (advanced)
 # SECTION: DIO
 # GROUP: Digital I/O
 
+[Digital I/O - Interface]
+label: Interface
+datatype: COMBO
+section: DIO
+group: Digital I/O
+def_value: LVCMOS
+show_in_measurement_dlg: False
+tooltip: <html><head/><body><p>Set the DIO interface.<br/><b>dios/0/interface</b></p></body></html>
+set_cmd: /dios/0/interface
+get_cmd: /dios/0/interface
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
+model_value_1: HDAWG8 (advanced)
+cmd_def_1: 0
+combo_def_1: LVCMOS
+cmd_def_2: 1
+combo_def_2: LVDS
+
+[Digital I/O - Mode]
+label: Mode
+datatype: COMBO
+section: DIO
+group: Digital I/O
+def_value: Manual
+show_in_measurement_dlg: False
+tooltip: <html><head/><body><p>Select DIO mode<br/><b>dios/0/mode</b></p></body></html>
+set_cmd: /dios/0/mode
+get_cmd: /dios/0/mode
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
+model_value_1: HDAWG8 (advanced)
+cmd_def_1: 0
+combo_def_1: Manual
+cmd_def_2: 1
+combo_def_2: AWG Sequencer
+cmd_def_3: 2
+combo_def_3: DIO Codeword
+cmd_def_4: 3
+combo_def_4: QCCS
+
 [Digital I/O - Output]
 label: Output
 datatype: DOUBLE
@@ -5520,12 +5726,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Sets the value of the DIO output for those bytes where 'drive' is enabled.<br/><b>dios/0/output</b></p></body></html>
 set_cmd: /dios/0/output
 get_cmd: /dios/0/output
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
 model_value_1: HDAWG8 (advanced)
 
-
-#########################################
-# SECTION: DIO
-# GROUP: Digital I/O
 
 [Digital I/O - Drive]
 label: Drive
@@ -5537,6 +5741,8 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>When on (1), the corresponding 8-bit bus is in output mode. When off (0), it is in input mode. Bit 0 corresponds to the least significant byte. For example, the value 1 drives the least significant byte, the value 8 drives the most significant byte.<br/><b>dios/0/drive</b></p></body></html>
 set_cmd: /dios/0/drive
 get_cmd: /dios/0/drive
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
 model_value_1: HDAWG8 (advanced)
 
 


### PR DESCRIPTION
 HDAWG driver updates

#### **The following changes are made in `.ini` file:**
##### **1) New parameters and options are added to `Setup` section:**
* Revisions - Data Server Version
* Revisions - Firmware Version
* Revisions - FPGA Version
* Preset - Factory Reset
* PQSC - Connect to PQSC
##### **2) Following options are hidden when connected to PQSC:**
* Device - Reference Clock
* Digital I/O - Interface
* Digital I/O - Mode
* Digital I/O - Output
* Digital I/O - Drive
##### **3) `Trigger Mode` of `Seqeuncer` sections are updated:**
* `External Trigger` is replaced with `Receive Trigger`
* `ZSync Trigger` trigger mode is added
##### **4) New options are added to `DIO` section:**
* Digital I/O - Interface
* Digital I/O - Mode
##### **5) Following options are hidden when ZSYNC trigger chosen:**
* Sequencer - Strobe Index
* Sequencer - Strobe Slope
* Sequencer - Valid Index
* Sequencer - Valid Polarity
* Sequencer - Codeword Mask
* Sequencer - Codeword Shift
#### **The following changes are made in `.py` file:**
##### **1) `performOpen` method updated:**
The revision parameters are read from the device and the Labber
controller is updated in the beginning, right after connection is
established.
##### **2) `factory_reset` and `connect_to_pqsc` methods are added:**
These methods call the necessary functions from zhinst-toolkit.
##### **3) `version_parser` method is added:**
This method is used to parse the data server version string.
##### **4) `performArm` method is updated:**
`External Trigger` is replaced with `Receive Trigger` and
`ZSync Trigger` is added to the arm condition.
##### **5) `update_labber_controller` method is added:**
This method is used to read a quantity from the device and update the
Labber controller with the current value obtained.
##### **6) `update_sequencers` method is updated:**
The sequencer parameters should be set when the trigger mode
selected is `ZSync Trigger` even when the sequence type is `None`. This
is necessary when the user wants to use the HDAWG as a bridge between
the PQSC and UHFQA actually using the AWG sequencer of the HDAWG.