### PR TITLE
UHFQA driver updates

### DIFF
--- a/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.ini
+++ b/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.ini
@@ -6,7 +6,7 @@
 name: Zurich Instruments HDAWG
 
 # The version string should be updated whenever changes are made to this config file
-version: 1.0
+version: 1.1
 
 # Name of folder containing the code defining a custom driver. Do not define this item
 # or leave it blank for any standard driver based on the built-in VISA interface.
@@ -65,6 +65,67 @@ use_visa: False
 #   stop_cmd:      Command used to stop a sweep
 
 
+#########################################
+# SECTION: Setup
+# GROUP: Revisions
+
+[Revisions - Data Server]
+label: Data Server
+datatype: STRING
+section: Setup
+group: Revisions
+def_value:
+tooltip: <html><head/><body><p>Contains the revision number of the Zurich Instruments Data Server.<br/><b>/zi/about/revision</b></p></body></html>
+get_cmd: /zi/about/revision
+permission: READ
+
+[Revisions - Firmware]
+label: Firmware
+datatype: STRING
+section: Setup
+group: Revisions
+def_value:
+tooltip: <html><head/><body><p>Revision of the device-internal controller software.<br/><b>/system/fwrevision</b></p></body></html>
+get_cmd: /system/fwrevision
+permission: READ
+
+[Revisions - FPGA]
+label: FPGA
+datatype: STRING
+section: Setup
+group: Revisions
+def_value:
+tooltip: <html><head/><body><p>HDL firmware revision.<br/><b>/system/fpgarevision</b></p></body></html>
+get_cmd: /system/fpgarevision
+permission: READ
+
+
+#########################################
+# SECTION: Setup
+# GROUP: Preset
+
+[Preset - Factory Reset]
+label: Factory Reset
+datatype: BUTTON
+section: Setup
+group: Preset
+tooltip: <html><head/><body><p>Load the factory default settings.<br/></p></body></html>
+permission: BOTH
+
+
+#########################################
+# SECTION: Setup
+# GROUP: PQSC
+
+[PQSC - Connect to PQSC]
+label: Connect to PQSC
+datatype: BOOLEAN
+section: Setup
+group: PQSC
+def_value: False
+tooltip: <html><head/><body><p>Configure the instrument to work with PQSC.<br/></p></body></html>
+permission: WRITE
+show_in_measurement_dlg: True
 
 
 #########################################
@@ -81,6 +142,8 @@ show_in_measurement_dlg: True
 tooltip: <html><head/><body><p>Reference clock source.<br/><b>system/clocks/referenceclock/source</b></p></body></html>
 set_cmd: /system/clocks/referenceclock/source
 get_cmd: /system/clocks/referenceclock/source
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
 cmd_def_1: 0
 combo_def_1: Internal
 cmd_def_2: 1
@@ -1713,8 +1776,9 @@ combo_def_1: None
 cmd_def_2: 1
 combo_def_2: Send Trigger
 cmd_def_3: 2
-combo_def_3: External Trigger
-
+combo_def_3: Receive Trigger
+cmd_def_4: 3
+combo_def_4: ZSync Trigger
 
 [Sequencer 1-2 - Alignment]
 label: Alignment
@@ -1730,20 +1794,20 @@ cmd_def_2: 1
 combo_def_2: End with Trigger
 
 
-[Sequencer 1-2 - Rerun]
-label: Rerun
+[Sequencer 1-2 - Single]
+label: Single
 datatype: COMBO
 section: Sequencer 1-2
 group: Sequencer 1-2
-def_value: Off
+def_value: On
 show_in_measurement_dlg: False
-tooltip: Reruns the Sequencer program continuously. This way of looping a program results in timing jitter. For a jitter free signal implement a loop directly in the sequence program.
+tooltip: Puts the Sequencer into single-shot mod.
 set_cmd: /awgs/0/single
 get_cmd: /awgs/0/single
 cmd_def_1: 0
-combo_def_1: On
+combo_def_1: Off
 cmd_def_2: 1
-combo_def_2: Off
+combo_def_2: On
 
 
 [Sequencer 1-2 - Sequence]
@@ -1786,7 +1850,7 @@ show_in_measurement_dlg: False
 def_value: 0
 unit: s
 state_quant: Sequencer 1-2 - Trigger Mode
-state_value_1: External Trigger
+state_value_1: Receive Trigger
 
 [Sequencer 1-2 - Repetitions]
 label: Repetitions
@@ -2193,6 +2257,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a trigger for the playback of a wave in connecton with waitDIOTrigger().<br/><b>awgs/0/dio/strobe/index</b></p></body></html>
 set_cmd: /awgs/0/dio/strobe/index
 get_cmd: /awgs/0/dio/strobe/index
+state_quant: Sequencer 1-2 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2206,6 +2274,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Select the signal edge that should activate the strobe trigger.<br/><b>awgs/0/dio/strobe/slope</b></p></body></html>
 set_cmd: /awgs/0/dio/strobe/slope
 get_cmd: /awgs/0/dio/strobe/slope
+state_quant: Sequencer 1-2 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -2227,6 +2299,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a valid bit.<br/><b>awgs/0/dio/valid/index</b></p></body></html>
 set_cmd: /awgs/0/dio/valid/index
 get_cmd: /awgs/0/dio/valid/index
+state_quant: Sequencer 1-2 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2240,6 +2316,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Polarity of the VALID bit that indicates that a codeword is available on the bus.<br/><b>awgs/0/dio/valid/polarity</b></p></body></html>
 set_cmd: /awgs/0/dio/valid/polarity
 get_cmd: /awgs/0/dio/valid/polarity
+state_quant: Sequencer 1-2 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -2261,6 +2341,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO bits to be used for waveform selection in connection with playWaveDIO().<br/><b>awgs/0/dio/mask/value</b></p></body></html>
 set_cmd: /awgs/0/dio/mask/value
 get_cmd: /awgs/0/dio/mask/value
+state_quant: Sequencer 1-2 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2274,6 +2358,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Defines the amount of bit shifting to apply for the DIO wave selection.<br/><b>awgs/0/dio/mask/shift</b></p></body></html>
 set_cmd: /awgs/0/dio/mask/shift
 get_cmd: /awgs/0/dio/mask/shift
+state_quant: Sequencer 1-2 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2376,7 +2464,9 @@ combo_def_1: None
 cmd_def_2: 1
 combo_def_2: Send Trigger
 cmd_def_3: 2
-combo_def_3: External Trigger
+combo_def_3: Receive Trigger
+cmd_def_4: 3
+combo_def_4: ZSync Trigger
 
 [Sequencer 3-4 - Alignment]
 label: Alignment
@@ -2391,20 +2481,20 @@ combo_def_1: Start with Trigger
 cmd_def_2: 1
 combo_def_2: End with Trigger
 
-[Sequencer 3-4 - Rerun]
-label: Rerun
+[Sequencer 3-4 - Single]
+label: Single
 datatype: COMBO
 section: Sequencer 3-4
 group: Sequencer 3-4
-def_value: Off
+def_value: On
 show_in_measurement_dlg: False
-tooltip: Reruns the Sequencer program continuously. This way of looping a program results in timing jitter. For a jitter free signal implement a loop directly in the sequence program.
+tooltip: Puts the Sequencer into single-shot mod.
 set_cmd: /awgs/1/single
 get_cmd: /awgs/1/single
 cmd_def_1: 0
-combo_def_1: On
+combo_def_1: Off
 cmd_def_2: 1
-combo_def_2: Off
+combo_def_2: On
 
 [Sequencer 3-4 - Sequence]
 label: Sequence
@@ -2445,7 +2535,7 @@ show_in_measurement_dlg: False
 def_value: 0
 unit: s
 state_quant: Sequencer 3-4 - Trigger Mode
-state_value_1: External Trigger
+state_value_1: Receive Trigger
 
 [Sequencer 3-4 - Repetitions]
 label: Repetitions
@@ -2854,6 +2944,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a trigger for the playback of a wave in connecton with waitDIOTrigger().<br/><b>awgs/1/dio/strobe/index</b></p></body></html>
 set_cmd: /awgs/1/dio/strobe/index
 get_cmd: /awgs/1/dio/strobe/index
+state_quant: Sequencer 3-4 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2867,6 +2961,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Select the signal edge that should activate the strobe trigger.<br/><b>awgs/1/dio/strobe/slope</b></p></body></html>
 set_cmd: /awgs/1/dio/strobe/slope
 get_cmd: /awgs/1/dio/strobe/slope
+state_quant: Sequencer 3-4 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -2888,6 +2986,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a valid bit.<br/><b>awgs/1/dio/valid/index</b></p></body></html>
 set_cmd: /awgs/1/dio/valid/index
 get_cmd: /awgs/1/dio/valid/index
+state_quant: Sequencer 3-4 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2901,6 +3003,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Polarity of the VALID bit that indicates that a codeword is available on the bus.<br/><b>awgs/1/dio/valid/polarity</b></p></body></html>
 set_cmd: /awgs/1/dio/valid/polarity
 get_cmd: /awgs/1/dio/valid/polarity
+state_quant: Sequencer 3-4 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -2922,6 +3028,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO bits to be used for waveform selection in connection with playWaveDIO().<br/><b>awgs/1/dio/mask/value</b></p></body></html>
 set_cmd: /awgs/1/dio/mask/value
 get_cmd: /awgs/1/dio/mask/value
+state_quant: Sequencer 3-4 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -2935,6 +3045,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Defines the amount of bit shifting to apply for the DIO wave selection.<br/><b>awgs/1/dio/mask/shift</b></p></body></html>
 set_cmd: /awgs/1/dio/mask/shift
 get_cmd: /awgs/1/dio/mask/shift
+state_quant: Sequencer 3-4 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -3037,7 +3151,9 @@ combo_def_1: None
 cmd_def_2: 1
 combo_def_2: Send Trigger
 cmd_def_3: 2
-combo_def_3: External Trigger
+combo_def_3: Receive Trigger
+cmd_def_4: 3
+combo_def_4: ZSync Trigger
 
 [Sequencer 5-6 - Alignment]
 label: Alignment
@@ -3052,20 +3168,20 @@ combo_def_1: Start with Trigger
 cmd_def_2: 1
 combo_def_2: End with Trigger
 
-[Sequencer 5-6 - Rerun]
-label: Rerun
+[Sequencer 5-6 - Single]
+label: Single
 datatype: COMBO
 section: Sequencer 5-6
 group: Sequencer 5-6
-def_value: Off
+def_value: On
 show_in_measurement_dlg: False
-tooltip: Reruns the Sequencer program continuously. This way of looping a program results in timing jitter. For a jitter free signal implement a loop directly in the sequence program.
+tooltip: Puts the Sequencer into single-shot mod.
 set_cmd: /awgs/2/single
 get_cmd: /awgs/2/single
 cmd_def_1: 0
-combo_def_1: On
+combo_def_1: Off
 cmd_def_2: 1
-combo_def_2: Off
+combo_def_2: On
 
 #########################################
 # SECTION: Sequencer 5-6
@@ -3080,7 +3196,7 @@ show_in_measurement_dlg: False
 def_value: 0
 unit: s
 state_quant: Sequencer 5-6 - Trigger Mode
-state_value_1: External Trigger
+state_value_1: Receive Trigger
 
 [Sequencer 5-6 - Repetitions]
 label: Repetitions
@@ -3522,6 +3638,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a trigger for the playback of a wave in connecton with waitDIOTrigger().<br/><b>awgs/2/dio/strobe/index</b></p></body></html>
 set_cmd: /awgs/2/dio/strobe/index
 get_cmd: /awgs/2/dio/strobe/index
+state_quant: Sequencer 5-6 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -3535,6 +3655,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Select the signal edge that should activate the strobe trigger.<br/><b>awgs/2/dio/strobe/slope</b></p></body></html>
 set_cmd: /awgs/2/dio/strobe/slope
 get_cmd: /awgs/2/dio/strobe/slope
+state_quant: Sequencer 5-6 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -3556,6 +3680,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a valid bit.<br/><b>awgs/2/dio/valid/index</b></p></body></html>
 set_cmd: /awgs/2/dio/valid/index
 get_cmd: /awgs/2/dio/valid/index
+state_quant: Sequencer 5-6 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -3569,6 +3697,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Polarity of the VALID bit that indicates that a codeword is available on the bus.<br/><b>awgs/2/dio/valid/polarity</b></p></body></html>
 set_cmd: /awgs/2/dio/valid/polarity
 get_cmd: /awgs/2/dio/valid/polarity
+state_quant: Sequencer 5-6 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -3590,6 +3722,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO bits to be used for waveform selection in connection with playWaveDIO().<br/><b>awgs/2/dio/mask/value</b></p></body></html>
 set_cmd: /awgs/2/dio/mask/value
 get_cmd: /awgs/2/dio/mask/value
+state_quant: Sequencer 5-6 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -3603,6 +3739,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Defines the amount of bit shifting to apply for the DIO wave selection.<br/><b>awgs/2/dio/mask/shift</b></p></body></html>
 set_cmd: /awgs/2/dio/mask/shift
 get_cmd: /awgs/2/dio/mask/shift
+state_quant: Sequencer 5-6 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -3705,7 +3845,9 @@ combo_def_1: None
 cmd_def_2: 1
 combo_def_2: Send Trigger
 cmd_def_3: 2
-combo_def_3: External Trigger
+combo_def_3: Receive Trigger
+cmd_def_4: 3
+combo_def_4: ZSync Trigger
 
 
 [Sequencer 7-8 - Alignment]
@@ -3721,20 +3863,20 @@ combo_def_1: Start with Trigger
 cmd_def_2: 1
 combo_def_2: End with Trigger
 
-[Sequencer 7-8 - Rerun]
-label: Rerun
+[Sequencer 7-8 - Single]
+label: Single
 datatype: COMBO
 section: Sequencer 7-8
 group: Sequencer 7-8
-def_value: Off
+def_value: On
 show_in_measurement_dlg: False
-tooltip: Reruns the Sequencer program continuously. This way of looping a program results in timing jitter. For a jitter free signal implement a loop directly in the sequence program.
+tooltip: Puts the Sequencer into single-shot mod.
 set_cmd: /awgs/3/single
 get_cmd: /awgs/3/single
 cmd_def_1: 0
-combo_def_1: On
+combo_def_1: Off
 cmd_def_2: 1
-combo_def_2: Off
+combo_def_2: On
 
 [Sequencer 7-8 - Trigger Delay]
 label: Trigger Delay
@@ -3745,7 +3887,7 @@ show_in_measurement_dlg: False
 def_value: 0
 unit: s
 state_quant: Sequencer 7-8 - Trigger Mode
-state_value_1: External Trigger
+state_value_1: Receive Trigger
 
 [Sequencer 7-8 - Repetitions]
 label: Repetitions
@@ -4190,6 +4332,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a trigger for the playback of a wave in connecton with waitDIOTrigger().<br/><b>awgs/3/dio/strobe/index</b></p></body></html>
 set_cmd: /awgs/3/dio/strobe/index
 get_cmd: /awgs/3/dio/strobe/index
+state_quant: Sequencer 7-8 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -4203,6 +4349,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Select the signal edge that should activate the strobe trigger.<br/><b>awgs/3/dio/strobe/slope</b></p></body></html>
 set_cmd: /awgs/3/dio/strobe/slope
 get_cmd: /awgs/3/dio/strobe/slope
+state_quant: Sequencer 7-8 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -4224,6 +4374,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO index to be used as a valid bit.<br/><b>awgs/3/dio/valid/index</b></p></body></html>
 set_cmd: /awgs/3/dio/valid/index
 get_cmd: /awgs/3/dio/valid/index
+state_quant: Sequencer 7-8 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -4237,6 +4391,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Polarity of the VALID bit that indicates that a codeword is available on the bus.<br/><b>awgs/3/dio/valid/polarity</b></p></body></html>
 set_cmd: /awgs/3/dio/valid/polarity
 get_cmd: /awgs/3/dio/valid/polarity
+state_quant: Sequencer 7-8 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
@@ -4258,6 +4416,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Selects the DIO bits to be used for waveform selection in connection with playWaveDIO().<br/><b>awgs/3/dio/mask/value</b></p></body></html>
 set_cmd: /awgs/3/dio/mask/value
 get_cmd: /awgs/3/dio/mask/value
+state_quant: Sequencer 7-8 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -4271,6 +4433,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Defines the amount of bit shifting to apply for the DIO wave selection.<br/><b>awgs/3/dio/mask/shift</b></p></body></html>
 set_cmd: /awgs/3/dio/mask/shift
 get_cmd: /awgs/3/dio/mask/shift
+state_quant: Sequencer 7-8 - Trigger Mode
+state_value_1: None
+state_value_2: Send Trigger
+state_value_3: Receive Trigger
 model_value_1: HDAWG8 (advanced)
 
 
@@ -5510,6 +5676,46 @@ model_value_1: HDAWG8 (advanced)
 # SECTION: DIO
 # GROUP: Digital I/O
 
+[Digital I/O - Interface]
+label: Interface
+datatype: COMBO
+section: DIO
+group: Digital I/O
+def_value: LVCMOS
+show_in_measurement_dlg: False
+tooltip: <html><head/><body><p>Set the DIO interface.<br/><b>dios/0/interface</b></p></body></html>
+set_cmd: /dios/0/interface
+get_cmd: /dios/0/interface
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
+model_value_1: HDAWG8 (advanced)
+cmd_def_1: 0
+combo_def_1: LVCMOS
+cmd_def_2: 1
+combo_def_2: LVDS
+
+[Digital I/O - Mode]
+label: Mode
+datatype: COMBO
+section: DIO
+group: Digital I/O
+def_value: Manual
+show_in_measurement_dlg: False
+tooltip: <html><head/><body><p>Select DIO mode<br/><b>dios/0/mode</b></p></body></html>
+set_cmd: /dios/0/mode
+get_cmd: /dios/0/mode
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
+model_value_1: HDAWG8 (advanced)
+cmd_def_1: 0
+combo_def_1: Manual
+cmd_def_2: 1
+combo_def_2: AWG Sequencer
+cmd_def_3: 2
+combo_def_3: DIO Codeword
+cmd_def_4: 3
+combo_def_4: QCCS
+
 [Digital I/O - Output]
 label: Output
 datatype: DOUBLE
@@ -5520,12 +5726,10 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Sets the value of the DIO output for those bytes where 'drive' is enabled.<br/><b>dios/0/output</b></p></body></html>
 set_cmd: /dios/0/output
 get_cmd: /dios/0/output
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
 model_value_1: HDAWG8 (advanced)
 
-
-#########################################
-# SECTION: DIO
-# GROUP: Digital I/O
 
 [Digital I/O - Drive]
 label: Drive
@@ -5537,6 +5741,8 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>When on (1), the corresponding 8-bit bus is in output mode. When off (0), it is in input mode. Bit 0 corresponds to the least significant byte. For example, the value 1 drives the least significant byte, the value 8 drives the most significant byte.<br/><b>dios/0/drive</b></p></body></html>
 set_cmd: /dios/0/drive
 get_cmd: /dios/0/drive
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
 model_value_1: HDAWG8 (advanced)
 
 

--- a/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.py
+++ b/Zurich_Instruments_HDAWG/Zurich_Instruments_HDAWG.py
@@ -10,7 +10,7 @@ HOST = "localhost"
 
 
 class Driver(LabberDriver):
-    """ This class implements a Labber driver"""
+    """This class implements a Labber driver"""
 
     def performOpen(self, options={}):
         """Perform the operation of opening the instrument connection"""
@@ -73,7 +73,9 @@ class Driver(LabberDriver):
             if value:
                 self.controller.awgs[i].enable_iq_modulation()
             else:
-                self.controller.awgs[i].disable_iq_modulation()    # overrides '.../system/awg/oscillatorcontrol' value for all channels
+                self.controller.awgs[
+                    i
+                ].disable_iq_modulation()  # overrides '.../system/awg/oscillatorcontrol' value for all channels
                 # fix '.../system/awg/oscillatorcontrol' value by calling enable_iq_modulation()
                 for value1 in range(4):
                     if self.controller.awgs[value1]._iq_modulation:
@@ -197,7 +199,7 @@ class Driver(LabberDriver):
                     self.controller.awgs[i].set_sequence_params(**params)
 
     def get_sequence_params(self, seq):
-        """Retrieves all sequence parameters from Labber quantities and returns 
+        """Retrieves all sequence parameters from Labber quantities and returns
         them as a dictionary, ready for `set_sequence_params(...)`."""
         base_name = f"Sequencer {2*seq + 1}-{2*seq + 2} - "
         params = dict(

--- a/Zurich_Instruments_MFLI/Zurich_Instruments_MFLI.py
+++ b/Zurich_Instruments_MFLI/Zurich_Instruments_MFLI.py
@@ -10,7 +10,7 @@ HOST = "localhost"
 
 
 class Driver(LabberDriver):
-    """ This class implements a Labber driver"""
+    """This class implements a Labber driver"""
 
     def performOpen(self, options={}):
         """Perform the operation of opening the instrument connection"""
@@ -241,7 +241,8 @@ class Driver(LabberDriver):
         try:
             node = self.controller.sweeper._get("gridnode")
             self.setValue(
-                "Sweeper Control - Status", f"Sweeping Parameter '{node}'",
+                "Sweeper Control - Status",
+                f"Sweeping Parameter '{node}'",
             )
             self.controller.sweeper.measure(timeout=timeout)
             self.setValue("Sweeper Control - Status", "Ready for Measurement")

--- a/Zurich_Instruments_UHFLI/Zurich_Instruments_UHFLI.py
+++ b/Zurich_Instruments_UHFLI/Zurich_Instruments_UHFLI.py
@@ -10,7 +10,7 @@ HOST = "localhost"
 
 
 class Driver(LabberDriver):
-    """ This class implements a Labber driver"""
+    """This class implements a Labber driver"""
 
     def performOpen(self, options={}):
         """Perform the operation of opening the instrument connection"""
@@ -194,11 +194,12 @@ class Driver(LabberDriver):
                 self.controller.awg.set_sequence_params(**params)
 
     def get_sequence_params(self):
-        """Retrieves all sequence parameters from Labber quantities and returns 
+        """Retrieves all sequence parameters from Labber quantities and returns
         them as a dictionary, ready for `set_sequence_params(...)`."""
         base_name = f"Sequencer - "
         params = dict(
-            sequence_type=self.getValue(base_name + "Sequence"), clock_rate=1.8e9,
+            sequence_type=self.getValue(base_name + "Sequence"),
+            clock_rate=1.8e9,
         )
         if params["sequence_type"] == "Pulse Train":
             params.update(repetitions=int(self.getValue(base_name + "Repetitions")))
@@ -351,7 +352,8 @@ class Driver(LabberDriver):
         try:
             node = self.controller.sweeper._get("gridnode")
             self.setValue(
-                "Sweeper Control - Status", f"Sweeping Parameter '{node}'",
+                "Sweeper Control - Status",
+                f"Sweeping Parameter '{node}'",
             )
             self.controller.sweeper.measure(timeout=timeout)
             self.setValue("Sweeper Control - Status", "Ready for Measurement")

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.ini
@@ -7,7 +7,7 @@
 name: Zurich Instruments UHFQA
 
 # The version string should be updated whenever changes are made to this config file
-version: 0.8
+version: 0.9
 
 # Name of folder containing the code defining a custom driver. Do not define this item
 # or leave it blank for any standard driver based on the built-in VISA interface.
@@ -79,6 +79,67 @@ use_visa: False
 #                        an instrument for a quantity that is defined as a a list of multiple options.
 #                        Only used when datatype is COMBO.
 
+#########################################
+# SECTION: Setup
+# GROUP: Revisions
+
+[Revisions - Data Server]
+label: Data Server
+datatype: STRING
+section: Setup
+group: Revisions
+def_value:
+tooltip: <html><head/><body><p>Contains the revision number of the Zurich Instruments Data Server.<br/><b>/zi/about/revision</b></p></body></html>
+get_cmd: /zi/about/revision
+permission: READ
+
+[Revisions - Firmware]
+label: Firmware
+datatype: STRING
+section: Setup
+group: Revisions
+def_value:
+tooltip: <html><head/><body><p>Revision of the device-internal controller software.<br/><b>/system/fwrevision</b></p></body></html>
+get_cmd: /system/fwrevision
+permission: READ
+
+[Revisions - FPGA]
+label: FPGA
+datatype: STRING
+section: Setup
+group: Revisions
+def_value:
+tooltip: <html><head/><body><p>HDL firmware revision.<br/><b>/system/fpgarevision</b></p></body></html>
+get_cmd: /system/fpgarevision
+permission: READ
+
+
+#########################################
+# SECTION: Setup
+# GROUP: Preset
+
+[Preset - Factory Reset]
+label: Factory Reset
+datatype: BUTTON
+section: Setup
+group: Preset
+tooltip: <html><head/><body><p>Load the factory default settings.<br/></p></body></html>
+permission: BOTH
+
+
+#########################################
+# SECTION: Setup
+# GROUP: PQSC
+
+[PQSC - Connect to PQSC]
+label: Connect to PQSC
+datatype: BOOLEAN
+section: Setup
+group: PQSC
+def_value: False
+tooltip: <html><head/><body><p>Configure the instrument to work with PQSC.<br/></p></body></html>
+permission: WRITE
+show_in_measurement_dlg: True
 
 
 #########################################
@@ -95,6 +156,8 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>10 MHz reference clock source.<br/><b>system/extclk</b></p></body></html>
 set_cmd: /system/extclk
 get_cmd: /system/extclk
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
 cmd_def_1: 0
 combo_def_1: Internal
 cmd_def_2: 1
@@ -2137,7 +2200,7 @@ datatype: VECTOR
 section: QA Monitor
 group: QA Monitor
 unit: V
-show_in_measurement_dlg: False
+show_in_measurement_dlg: True
 permission: READ
 x_name: Time
 x_unit: s
@@ -2147,7 +2210,7 @@ datatype: VECTOR
 section: QA Monitor
 group: QA Monitor
 unit: V
-show_in_measurement_dlg: False
+show_in_measurement_dlg: True
 permission: READ
 x_name: Time
 x_unit: s
@@ -3329,9 +3392,9 @@ show_in_measurement_dlg: True
 cmd_def_1: 0
 combo_def_1: None
 cmd_def_2: 1
-combo_def_2: Send Trigger
+combo_def_2: Receive Trigger
 cmd_def_3: 2
-combo_def_3: External Trigger
+combo_def_3: ZSync Trigger
 tooltip: This parameter specifies whether the UHFQA is used as a master trigger, expects a trigger or is used by itself.
 
 [Sequencer - Alignment]
@@ -3347,6 +3410,21 @@ combo_def_1: Start with Trigger
 cmd_def_2: 1
 combo_def_2: End with Trigger
 
+[Sequencer - Single]
+label: Single
+datatype: COMBO
+section: Sequencer
+group: Sequencer
+def_value: Off
+show_in_measurement_dlg: False
+tooltip: Puts the Sequencer into single-shot mod
+set_cmd: /awgs/0/single
+get_cmd: /awgs/0/single
+cmd_def_1: 0
+combo_def_1: Off
+cmd_def_2: 1
+combo_def_2: On
+
 [Sequencer - Trigger Delay]
 label: Trigger Delay
 datatype: DOUBLE
@@ -3356,7 +3434,7 @@ show_in_measurement_dlg: False
 def_value: 0
 unit: s
 state_quant: Sequencer - Trigger Mode
-state_value_1: External Trigger
+state_value_1: Receive Trigger
 
 [Sequencer - Period]
 label: Period
@@ -3466,6 +3544,83 @@ state_quant: Sequencer - Sequence
 state_value: Pulsed Spectroscopy
 
 #########################################
+# SECTION: AWG Sequencer
+# GROUP: DIO Trigger
+
+[Sequencer - Strobe Index]
+label: Strobe Index
+datatype: DOUBLE
+section: Sequencer
+group: DIO Trigger
+def_value: 0
+show_in_measurement_dlg: False
+tooltip: <html><head/><body><p>Selects the DIO index to be used as a trigger for the playback of a wave in connecton with waitDIOTrigger().<br/><b>awgs/0/dio/strobe/index</b></p></body></html>
+set_cmd: /awgs/0/dio/strobe/index
+get_cmd: /awgs/0/dio/strobe/index
+state_quant: Sequencer - Trigger Mode
+state_value_1: None
+state_value_2: Receive Trigger
+
+[Sequencer - Strobe Slope]
+label: Strobe Slope
+datatype: COMBO
+section: Sequencer
+group: DIO Trigger
+def_value: None
+show_in_measurement_dlg: False
+tooltip: <html><head/><body><p>Select the signal edge that should activate the strobe trigger.<br/><b>awgs/0/dio/strobe/slope</b></p></body></html>
+set_cmd: /awgs/0/dio/strobe/slope
+get_cmd: /awgs/0/dio/strobe/slope
+state_quant: Sequencer - Trigger Mode
+state_value_1: None
+state_value_2: Receive Trigger
+cmd_def_1: 0
+combo_def_1: None
+cmd_def_2: 1
+combo_def_2: Rising
+cmd_def_3: 2
+combo_def_3: Falling
+cmd_def_4: 3
+combo_def_4: Both
+
+[Sequencer - Valid Index]
+label: Valid Index
+datatype: DOUBLE
+section: Sequencer
+group: DIO Trigger
+def_value: 0
+show_in_measurement_dlg: False
+tooltip: <html><head/><body><p>Selects the DIO index to be used as a valid bit.<br/><b>awgs/0/dio/valid/index</b></p></body></html>
+set_cmd: /awgs/0/dio/valid/index
+get_cmd: /awgs/0/dio/valid/index
+state_quant: Sequencer - Trigger Mode
+state_value_1: None
+state_value_2: Receive Trigger
+
+[Sequencer - Valid Polarity]
+label: Valid Polarity
+datatype: COMBO
+section: Sequencer
+group: DIO Trigger
+def_value: None
+show_in_measurement_dlg: False
+tooltip: <html><head/><body><p>Polarity of the VALID bit that indicates that a codeword is available on the bus.<br/><b>awgs/0/dio/valid/polarity</b></p></body></html>
+set_cmd: /awgs/0/dio/valid/polarity
+get_cmd: /awgs/0/dio/valid/polarity
+state_quant: Sequencer - Trigger Mode
+state_value_1: None
+state_value_2: Receive Trigger
+cmd_def_1: 0
+combo_def_1: None
+cmd_def_2: 1
+combo_def_2: Low
+cmd_def_3: 2
+combo_def_3: High
+cmd_def_4: 3
+combo_def_4: Both
+
+
+#########################################
 # SECTION: Oscillator
 # GROUP: Oscillator
 
@@ -3494,17 +3649,21 @@ label: Mode
 datatype: COMBO
 section: DIO
 group: Digital I/O
-def_value: Normal
 show_in_measurement_dlg: False
+def_value: Manual
 tooltip: <html><head/><body><p>Select DIO mode<br/><b>dios/0/mode</b></p></body></html>
 set_cmd: /dios/0/mode
 get_cmd: /dios/0/mode
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
 cmd_def_1: 0
-combo_def_1: Normal
+combo_def_1: Manual
 cmd_def_2: 1
 combo_def_2: AWG Sequencer
 cmd_def_3: 2
 combo_def_3: QA Result
+cmd_def_4: 4
+combo_def_4: QA Result QCCS
 
 [Digital I/O - Output]
 label: Output
@@ -3516,6 +3675,8 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Sets the value of the DIO output for those bytes where 'drive' is enabled.<br/><b>dios/0/output</b></p></body></html>
 set_cmd: /dios/0/output
 get_cmd: /dios/0/output
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
 
 
 [Digital I/O - Drive]
@@ -3528,6 +3689,8 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>When on (1), the corresponding 8-bit bus is in output mode. When off (0), it is in input mode. Bit 0 corresponds to the least significant byte. For example, the value 1 drives the least significant byte, the value 8 drives the most significant byte.<br/><b>dios/0/drive</b></p></body></html>
 set_cmd: /dios/0/drive
 get_cmd: /dios/0/drive
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
 
 
 [Digital I/O - Ext Clock]
@@ -3540,11 +3703,14 @@ show_in_measurement_dlg: False
 tooltip: <html><head/><body><p>Select DIO internal or external clocking.<br/><b>dios/0/extclk</b></p></body></html>
 set_cmd: /dios/0/extclk
 get_cmd: /dios/0/extclk
+state_quant: PQSC - Connect to PQSC
+state_value_1: False
 cmd_def_1: 0
 combo_def_1: Internal 56 MHz
 cmd_def_2: 1
 combo_def_2: Clk Pin 68
-
+cmd_def_3: 2
+combo_def_3: Internal 50 MHz
 
 
 #########################################

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.py
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.py
@@ -10,7 +10,7 @@ HOST = "localhost"
 
 
 class Driver(LabberDriver):
-    """ This class implements a Labber driver"""
+    """This class implements a Labber driver"""
 
     def performOpen(self, options={}):
         """Perform the operation of opening the instrument connection"""
@@ -155,11 +155,15 @@ class Driver(LabberDriver):
         elif quant.name == "Result Demod 1-2":
             # calculate 'demod 1-2' value
             return self.get_demod_12()
-        elif quant.name == 'QA Monitor - Input 1':
-            value = quant.getTraceDict(self.controller._get('/qas/0/monitor/inputs/0/wave'), dt=1/1.8e9)
+        elif quant.name == "QA Monitor - Input 1":
+            value = quant.getTraceDict(
+                self.controller._get("/qas/0/monitor/inputs/0/wave"), dt=1 / 1.8e9
+            )
             return value
-        elif quant.name == 'QA Monitor - Input 2':
-            value = quant.getTraceDict(self.controller._get('/qas/0/monitor/inputs/1/wave'), dt=1/1.8e9)
+        elif quant.name == "QA Monitor - Input 2":
+            value = quant.getTraceDict(
+                self.controller._get("/qas/0/monitor/inputs/1/wave"), dt=1 / 1.8e9
+            )
             return value
         else:
             return quant.getValue()
@@ -201,7 +205,7 @@ class Driver(LabberDriver):
                 self.controller.awg.set_sequence_params(**params)
 
     def get_sequence_params(self):
-        """Retrieves all sequence parameters from Labber quantities and returns 
+        """Retrieves all sequence parameters from Labber quantities and returns
         them as a dictionary, ready for `set_sequence_params(...)`."""
         base_name = f"Sequencer - "
         params = dict(
@@ -257,7 +261,7 @@ class Driver(LabberDriver):
         self.controller.crosstalk_matrix(matrix)
 
     def get_demod_12(self):
-        """Assembles a complex value from real valued data on channel 1 and 2. 
+        """Assembles a complex value from real valued data on channel 1 and 2.
         The returned data will be (channel 1) + i * (channel 2).
         """
         data1 = self.controller.channels[0].result()

--- a/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.py
+++ b/Zurich_Instruments_UHFQA/Zurich_Instruments_UHFQA.py
@@ -1,19 +1,39 @@
-import time
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
+"""Labber Driver for the Zurich Instruments UHFQA Quantum Analyzer.
+
+This driver provides a high-level interface of the Zurich Instruments
+UHFQA Quantum Analyzer for the scientific measurement software Labber.
+It is based on the Zurich Instruments Toolkit (zhinst-toolkit), an
+extension of our Python API ziPython for high-level instrument control.
+"""
+
 import numpy as np
 from BaseDriver import LabberDriver, Error
 
 import zhinst.toolkit as tk
-
 
 # change this value in case you are not using 'localhost'
 HOST = "localhost"
 
 
 class Driver(LabberDriver):
-    """This class implements a Labber driver"""
+    """Implement a Labber Driver for the Zurich Instruments UHFQA."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.controller = None
+        self.last_length = []
+        self.sequencer_updated = False
+        self.waveforms_updated = []
+        self.replace_waveform = False
 
     def performOpen(self, options={}):
-        """Perform the operation of opening the instrument connection"""
+        """Perform the operation of opening the instrument connection."""
+        # Get the interface selected in UI,
+        # restrict to either 'USB' or '1GbE'
         interface = self.comCfg.interface
         if not interface == "USB":
             interface = "1GbE"
@@ -23,32 +43,53 @@ class Driver(LabberDriver):
         )
         self.controller.setup()
         self.controller.connect_device()
-        self.last_length = [0] * 2
+        # Read the revision numbers after the connection
+        # and update Labber controller.
+        self.update_labber_controller("Revisions - Data Server")
+        self.update_labber_controller("Revisions - Firmware")
+        self.update_labber_controller("Revisions - FPGA")
+        # Initialize last waveform lengths as 0
+        self.last_length = [0] * 8
 
     def performClose(self, bError=False, options={}):
-        """Perform the close instrument connection operation"""
+        """Perform the close instrument connection operation."""
         pass
 
     def initSetConfig(self):
-        """This function is run before setting values in Set Config"""
+        """Run before setting values in Set Config."""
         pass
 
     def performSetValue(self, quant, value, sweepRate=0.0, options={}):
-        """Perform the Set Value instrument operation. This function should
-        return the actual value set by the instrument"""
+        """Perform the Set Value instrument operation.
 
+        For numerical quantities, this function returns the
+        actual value set by the instrument.
+        """
+        if quant.set_cmd:
+            # if a 'set_cmd' is defined, just set the node
+            self.set_node_value(quant, value)
+            if quant.datatype == quant.DOUBLE:
+                # If the quantity is numerical,
+                # read the actual value from the device
+                value = self.get_node_value(quant)
+        # Update the current local value of the quantity of the driver
         quant.setValue(value)
-
+        # Get the current hardware loop index and total number of
+        # points of the hardware loop.
+        loop_index, n_HW_loop = self.getHardwareLoopIndex(options)
+        # Reset all updated flags to `False`
         if self.isFirstCall(options):
             self.sequencer_updated = False
             self.waveforms_updated = [False] * 2
             self.replace_waveform = False
 
-        loop_index, n_HW_loop = self.getHardwareLoopIndex(options)
-
-        # if a 'set_cmd' is defined, just set the node
-        if quant.set_cmd:
-            value = self.set_node_value(quant, value)
+        # Setup tab
+        if quant.name == "Preset - Factory Reset":
+            # Load factory preset
+            self.controller.factory_reset(sync=True)
+        if quant.name == "PQSC - Connect to PQSC":
+            # Establish connection to PQSC
+            self.connect_to_pqsc(value)
 
         # sequencer outputs
         if quant.name == "Control - Output 1":
@@ -66,7 +107,7 @@ class Driver(LabberDriver):
 
         # crosstalk - reset button
         if quant.name == "Crosstalk - Reset":
-            self.set_cosstalk_matrix(np.eye(10))
+            self.set_crosstalk_matrix(np.eye(10))
 
         # integration time
         if quant.name == "Integration - Time":
@@ -134,62 +175,93 @@ class Driver(LabberDriver):
         return value
 
     def performGetValue(self, quant, options={}):
-        """Perform the Get Value instrument operation"""
+        """Perform the Get Value instrument operation."""
         if quant.get_cmd:
             # if a 'get_cmd' is defined, use it to return the node value
-            return self.controller._get(quant.get_cmd)
-        elif quant.name.startswith("Result Vector - QB"):
+            value = self.get_node_value(quant)
+            # Update the current local value of the quantity of the driver
+            quant.setValue(value)
+        else:
+            # for other quantities, just return current value of control
+            value = quant.getValue()
+
+        # Get the current hardware loop index and total number of
+        # points of the hardware loop.
+        loop_index, n_HW_loop = self.getHardwareLoopIndex(options)
+
+        if quant.name.startswith("Result Vector - QB"):
             # get the result vector
             i = int(quant.name[-2:]) - 1
-            value = self.controller.channels[i].result()
-            return quant.getTraceDict(value, x0=0, dx=1)
-        elif quant.name.startswith("Result Avg - QB"):
+            data = self.controller.channels[i].result()
+            value = quant.getTraceDict(data, x0=0, dx=1)
+        if quant.name.startswith("Result Avg - QB"):
             # get the _averaged_ result vector
             i = int(quant.name[-2:]) - 1
-            value = self.controller.channels[i].result()
+            data = self.controller.channels[i].result()
             if self.isHardwareLoop(options):
-                index, _ = self.getHardwareLoopIndex(options)
-                return value[index]
+                value = data[loop_index]
             else:
-                return np.mean(value)
-        elif quant.name == "Result Demod 1-2":
+                value = np.mean(data)
+        if quant.name == "Result Demod 1-2":
             # calculate 'demod 1-2' value
-            return self.get_demod_12()
-        elif quant.name == "QA Monitor - Input 1":
-            value = quant.getTraceDict(
-                self.controller._get("/qas/0/monitor/inputs/0/wave"), dt=1 / 1.8e9
-            )
-            return value
-        elif quant.name == "QA Monitor - Input 2":
-            value = quant.getTraceDict(
-                self.controller._get("/qas/0/monitor/inputs/1/wave"), dt=1 / 1.8e9
-            )
-            return value
-        else:
-            return quant.getValue()
+            value = self.get_demod_12()
+        if quant.name == "QA Monitor - Input 1":
+            data = self.controller._get("/qas/0/monitor/inputs/0/wave")
+            value = quant.getTraceDict(data, dt=1 / 1.8e9)
+        if quant.name == "QA Monitor - Input 2":
+            data = self.controller._get("/qas/0/monitor/inputs/1/wave")
+            value = quant.getTraceDict(data, dt=1 / 1.8e9)
+
+        return value
 
     def performArm(self, quant_names, options={}):
         """Perform the instrument arm operation"""
         if self.getValue("QA Results - Enable"):
             self.controller._set("/qas/0/result/enable", 1)
             self.controller.arm()
-        if self.getValue("Sequencer - Trigger Mode") == "External Trigger":
+        if self.getValue("Sequencer - Trigger Mode") in [
+            "Receive Trigger",
+            "ZSync Trigger",
+        ]:
             self.controller.awg.run()
 
+    def update_labber_controller(self, quant_name):
+        """Read the quantity from device and update the Labber controller."""
+        value = self.readValueFromOther(quant_name)
+        self.setValue(quant_name, str(value))
+
     def set_node_value(self, quant, value):
+        """Perform node and parameter set
+
+        This method uses the zhinst-toolkit setter to set the node
+        and parameter values.
+        """
         if quant.datatype == quant.COMBO:
+            # If the quantity type is combo, extract the index and
+            # check if a list of command strings is defined
             i = quant.getValueIndex(value)
             if len(quant.cmd_def) == 0:
                 self.controller._set(quant.set_cmd, i)
             else:
                 self.controller._set(quant.set_cmd, quant.cmd_def[i])
         else:
+            # Otherwise, just send the value to the device
             self.controller._set(quant.set_cmd, value)
-        return self.controller._get(quant.get_cmd)
+        return value
+
+    def get_node_value(self, quant):
+        """Perform node get
+
+        This method uses the zhinst-toolkit getter to get the node
+        and parameter values.
+        """
+        # Read the value from device
+        value = self.controller._get(quant.get_cmd)
+        return value
 
     def awg_start_stop(self, quant, value):
         """Handles setting of nodes with 'set_cmd'."""
-        if value:
+        if not self.controller.awg.is_running and value:
             self.controller.awg.run()
         else:
             self.controller.awg.stop()
@@ -203,6 +275,16 @@ class Driver(LabberDriver):
             params = self.get_sequence_params()
             if params["sequence_type"] != "None":
                 self.controller.awg.set_sequence_params(**params)
+            if params["trigger_mode"] == "ZSync Trigger":
+                if params["sequence_type"] == "None":
+                    self.controller.awg.set_sequence_params(
+                        trigger_mode="ZSync Trigger"
+                    )
+                # read the relevant settings from the device and update
+                # the Labber controller
+                self.update_labber_controller("Sequencer - Strobe Slope")
+                self.update_labber_controller("Sequencer - Valid Polarity")
+                self.update_labber_controller("Sequencer - Valid Index")
 
     def get_sequence_params(self):
         """Retrieves all sequence parameters from Labber quantities and returns
@@ -252,7 +334,7 @@ class Driver(LabberDriver):
         if sequence_type == "Simple":
             self.controller.awg.upload_waveforms()
 
-    def set_cosstalk_matrix(self, matrix):
+    def set_crosstalk_matrix(self, matrix):
         """Set the crosstalk matrix as a 2D numpy array."""
         rows, cols = matrix.shape
         for r in range(rows):
@@ -269,3 +351,11 @@ class Driver(LabberDriver):
         real = np.mean(np.real(data1))
         imag = np.mean(np.real(data2))
         return real + 1j * imag
+
+    def connect_to_pqsc(self, value):
+        if value:
+            self.controller.enable_qccs_mode()
+            self.update_labber_controller("Device - Reference Clock")
+            self.update_labber_controller("Digital I/O - Ext Clock")
+            self.update_labber_controller("Digital I/O - Mode")
+            self.update_labber_controller("Digital I/O - Drive")


### PR DESCRIPTION
#### **The following changes are made in `.ini` file:**
##### **1) New parameters and options are added to `Setup` section:**
* Revisions - Data Server Version
* Revisions - Firmware Version
* Revisions - FPGA Version
* Preset - Factory Reset
* PQSC - Connect to PQSC
##### **2) Following options are hidden when connected to PQSC:**
* Device - Reference Clock
* Digital I/O - Mode
* Digital I/O - Output
* Digital I/O - Drive
* Digital I/O - Ext Clock
##### **3) `QA Monitor - Inputs` are updated:**
`QA Monitor - Input 1` and `QA Monitor - Input 2` are shown 
automatically in measurement window.
##### **4) `Trigger Mode` of `Seqeuncer` section is updated:**
* `External Trigger` is replaced with `Receive Trigger`
* `ZSync Trigger` trigger mode is added
##### **5) `Rerun` option is added to `Sequencer` section**
##### **6) `Digital I/O - Mode` updated:**
* `Normal` options is renamed to `Manual` as in LabOne GUI.
* `QA Result QCCS` option is added.
##### **7) `Digital I/O - Ext Clock` updated:**
* `Internal 50 MHz` option is added.
##### **8) Following options are added to `Sequencer` section:**
* Sequencer - Strobe Index
* Sequencer - Strobe Slope
* Sequencer - Valid Index
* Sequencer - Valid Polarity
Note that these options are automatically hidden if the selected trigger
mode is `ZSync Trigger`
#### **The following changes are made in `.py` file:**
##### **1) `performOpen` method updated:**
The revision parameters are read from the device and the Labber
controller is updated in the beginning, right after connection is
established. 
##### **2) `factory_reset` and `connect_to_pqsc` methods are added:**
These methods call the necessary functions from zhinst-toolkit.
##### **3) `version_parser` method is added:**
This method is used to parse the data server version string.
##### **4) `performArm` method is updated:**
`External Trigger` is replaced with `Receive Trigger` and 
`ZSync Trigger` is added to the arm condition.
##### **5) `update_labber_controller` method is added:**
This method is used to read a quantity from the device and update the
Labber controller with the current value obtained.
##### **6) `update_sequencers` method is updated:**
The sequencer parameters should be set when the trigger mode 
selected is `ZSync Trigger` even when the sequence type is `None`.