### PR TITLE
Fix ini for SHFQA

### DIFF
--- a/Zurich_Instruments_SHFQA/Zurich_Instruments_SHFQA.ini
+++ b/Zurich_Instruments_SHFQA/Zurich_Instruments_SHFQA.ini
@@ -1888,7 +1888,7 @@ datatype: COMBO
 group: Readout 1
 section: QA Result
 label: Mode
-def_value: 0
+def_value: cyclic
 combo_def_1: cyclic
 cmd_def_1: 0
 combo_def_2: sequential
@@ -2911,7 +2911,7 @@ datatype: COMBO
 group: Readout 2
 section: QA Result
 label: Mode
-def_value: 0
+def_value: cyclic
 combo_def_1: cyclic
 cmd_def_1: 0
 combo_def_2: sequential
@@ -3930,7 +3930,7 @@ datatype: COMBO
 group: Readout 3
 section: QA Result
 label: Mode
-def_value: 0
+def_value: cyclic
 combo_def_1: cyclic
 cmd_def_1: 0
 combo_def_2: sequential
@@ -4883,7 +4883,7 @@ datatype: COMBO
 group: Readout 4
 section: QA Result
 label: Mode
-def_value: 0
+def_value: cyclic
 combo_def_1: cyclic
 cmd_def_1: 0
 combo_def_2: sequential


### PR DESCRIPTION
The default values of combo boxes were wrong, so SHFQA couldn't be connected via labber.