### PR TITLE
Fixed issue where VECTOR quantities set value was handled incorrectly…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # zhinst-labber Changelog
 
+## Version 0.3.1
+
+* Added support for `dict` type in `values` key when `Quantity` datatype is `VECTOR`. The settings value
+  `vector_quantity_value_map_array_keys` points to the correct key in the `dict`.
 
 ## Version 0.3.0
 * Adapt drivers to ``zhinst-toolkit`` 0.3.x which is a major refactoring and improves

--- a/docs/source/first_steps/quickstart.rst
+++ b/docs/source/first_steps/quickstart.rst
@@ -102,6 +102,7 @@ The ``settings.json`` has the following structure:
             "base_type": "device",
             "type": "UHFLI"
         }
+        "vector_quantity_value_map_array_keys": ["y"],
         "logger_level": 20
         "logger_path": "Path\\to\\log\\output.log"
     }
@@ -113,6 +114,8 @@ The ``settings.json`` has the following structure:
 * **shared_session**: If true the instrument reuses a session to a data server.
   Sharing a session is enabled by default and increases the setup speed as well
   as resource consumption.
+* **vector_quantity_value_map_array_keys**: If vector quantity value is a dictionary instead of an array,
+  the values in the list defines the key from where the vector can be found. First matching key is used.
 * **logger_level**: Used logger level. If not specified the default logger level
   (Info = 20) from zhinst-labber is used.
 * **logger_path**: Optional path for storing the logger output to a path. (In

--- a/src/zhinst/labber/generator/generator.py
+++ b/src/zhinst/labber/generator/generator.py
@@ -225,6 +225,7 @@ class DeviceConfig(LabberConfig):
                 "shared_session": True,
             },
             "instrument": {"base_type": "device", "type": self._name},
+            "vector_quantity_value_map_array_keys": ["y"],
         }
         version = f"{session.about.version()}#{__version__}#{self.env_settings.version}"
         self._general_settings = {


### PR DESCRIPTION
 Fixed issue where VECTOR quantities set value was handled incorrectly (#19)

* Added `vector_quantity_value_map_array_keys` to device settings.json. This list can be used to define key value for arrays in quantity data.