### PR TITLE
Skip command table node set on empty value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # zhinst-labber Changelog
 
+## Version 0.3.2
+
+- Fixed issue where an empty command table was sent to the device when the node has no value defined in Labber UI,
+  resulting in LabOne UI warnings
+- Fixed issue where setting Nodes with enumerated values issued a warning to the Labber log
+
 ## Version 0.3.1
 
 * Added automatic Zurich Instruments static driver generation when generating new drivers.

--- a/src/zhinst/labber/driver/base_instrument.py
+++ b/src/zhinst/labber/driver/base_instrument.py
@@ -479,6 +479,8 @@ class BaseDevice(LabberDriver):
         Returns:
             Waveform object.
         """
+        if waves1 is None:
+            return Waveforms()
         wave0_reader = csv.reader(
             waves1.open("r", newline=""), delimiter=",", quotechar="|"
         )

--- a/src/zhinst/labber/driver/base_instrument.py
+++ b/src/zhinst/labber/driver/base_instrument.py
@@ -434,7 +434,7 @@ class BaseDevice(LabberDriver):
         try:
             # get enumerated value if there is one
             if quant.cmd_def:
-                value = quant.cmd_def[quant.combo_defs.index(value)]
+                value = int(quant.cmd_def[quant.combo_defs.index(value)])
             # VECTOR datatype value can also be a dictionary, where the value of the quant is "y" key.
             if quant.datatype == 4:  # VECTOR enum value
                 if isinstance(value, dict):

--- a/src/zhinst/labber/resources/settings.json
+++ b/src/zhinst/labber/resources/settings.json
@@ -256,7 +256,8 @@
                 "driver": {
                     "function": "commandtable/upload_to_device",
                     "function_path": "../upload_to_device",
-                    "type": "JSON"
+                    "type": "JSON",
+                    "call_empty": false
                 }
             },
             "/*/sequencer_program": {

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -234,6 +234,26 @@ class TestBase:
         quant = create_quant_mock("Test - Name", device_driver, "", "")
         assert device_driver.performSetValue(quant, 0) == quant.getValue()
 
+    def test_performSet_enumerated_node(self, mock_toolkit_session, device_driver):
+        def _create_quant_mock(name, instrument, set_cmd, get_cmd, datatype=""):
+            quant = Mock(spec=InstrumentQuantity)
+            quant.name = name
+            quant.set_cmd = set_cmd
+            quant.get_cmd = get_cmd
+            quant.cmd_def = ["0", "1"]
+            quant.combo_defs = ["option1", "option2"]
+            quant.datatype = datatype
+            instrument._node_quant_map[instrument._quant_to_path(name)] = name
+            return quant
+
+        device_driver.comCfg.getAddressString.return_value = "DEV1234"
+        device_driver.performOpen()
+
+        # Standart node set
+        quant = _create_quant_mock("Test - Name", device_driver, "test/node", "")
+        device_driver.performSetValue(quant, "option2")
+        device_driver._instrument[quant.set_cmd].assert_called_with(1)
+
     def test_performSet_transaction_node(self, mock_toolkit_session, device_driver):
         device_driver.comCfg.getAddressString.return_value = "DEV1234"
         device_driver.performOpen()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -499,7 +499,7 @@ class TestBase:
         assert input == device_driver.performSetValue(quant, input)
         device_driver._instrument.awgs[
             0
-        ].commandtable.upload_to_device.assert_called_with(ct={})
+        ].commandtable.upload_to_device.assert_not_called()
 
         # valid input
         input = Path("tests/data/test.json")


### PR DESCRIPTION
This PR fixes an issue where LabOne error log showed that command table cannot be uploaded before ELF, even though no command table is not defined.

Currently when command table file path value is empty, an empty command table is sent to the device. Historically this was used to reset the command table.

However, this produces an error in LabOne DataServer log, that ELF must be loaded first, even though a command table was never meant to be uploaded. If command table must be reset, it should be done via appropriate node: `../commandtable/clear`

---

It also ensures that enumerated node values are called with an integer, not string
